### PR TITLE
Stickbreaker reset cleanup

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -484,8 +484,7 @@ void TwoWire::flush(void)
 
 void TwoWire::reset(void)
 {
-    i2cFreeQueue(i2c); // release malloc memory
-    i2cReleaseISR(i2c); // remove ISR from Interrupt chain
+    i2cReleaseISR(i2c); // remove ISR from Interrupt chain,Delete EventGroup,Free Heap memory
     i2cReset( i2c );
     i2c = NULL;
     begin( sda, scl );

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -484,6 +484,8 @@ void TwoWire::flush(void)
 
 void TwoWire::reset(void)
 {
+    i2cFreeQueue(i2c); // release malloc memory
+    i2cReleaseISR(i2c); // remove ISR from Interrupt chain
     i2cReset( i2c );
     i2c = NULL;
     begin( sda, scl );


### PR DESCRIPTION
fix memory leak, If Wire.reset() was called, Heap allocations, EventGroup, ISR would not be freed