### PR TITLE
Create Destructor for Wire Class.

### DIFF
--- a/cores/esp32/esp32-hal-i2c.h
+++ b/cores/esp32/esp32-hal-i2c.h
@@ -148,11 +148,12 @@ typedef struct i2c_struct_t i2c_t;
 
 i2c_t * i2cInit(uint8_t i2c_num);
 
+/* unused, 03/18/2018 fixed with V0.2.0
 //call this after you setup the bus and pins to send empty packet
 //required because when pins are attached, they emit pulses that lock the bus
 void i2cInitFix(i2c_t * i2c);
-
 void i2cReset(i2c_t* i2c);
+*/
 
 i2c_err_t i2cSetFrequency(i2c_t * i2c, uint32_t clk_speed);
 uint32_t i2cGetFrequency(i2c_t * i2c);
@@ -167,7 +168,7 @@ i2c_err_t i2cProcQueue(i2c_t *i2c, uint32_t *readCount, uint16_t timeOutMillis);
 i2c_err_t i2cAddQueueWrite(i2c_t *i2c, uint16_t i2cDeviceAddr, uint8_t *dataPtr, uint16_t dataLen, bool SendStop, EventGroupHandle_t event);
 i2c_err_t i2cAddQueueRead(i2c_t *i2c, uint16_t i2cDeviceAddr, uint8_t *dataPtr, uint16_t dataLen, bool SendStop, EventGroupHandle_t event);
 i2c_err_t i2cFreeQueue(i2c_t *i2c);
-i2c_err_t i2cReleaseISR(i2c_t *i2c);
+void i2cReleaseAll(i2c_t *i2c); // free ISR, Free DQ, Power off peripheral clock.  Must call i2cInit(),i2cSetFrequency() to recover
 //stickbreaker debug support
 void i2cDumpInts(uint8_t num);
 void i2cDumpI2c(i2c_t *i2c);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,7 +30,7 @@
 #include "freertos/queue.h"
 #include "Stream.h"
 
-#define STICKBREAKER V0.2.1
+#define STICKBREAKER V0.2.2
 #define I2C_BUFFER_LENGTH 128
 typedef void(*user_onRequest)(void);
 typedef void(*user_onReceive)(uint8_t*, int);

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -70,8 +70,10 @@ protected:
 public:
     TwoWire(uint8_t bus_num);
     ~TwoWire();
-    void begin(int sda=-1, int scl=-1, uint32_t frequency=100000);
-    void setClock(uint32_t);
+    void begin(int sda=-1, int scl=-1, uint32_t frequency=0); 
+       //defaults bus:0 sda=SDA, scl=SCL, frequency =100khz via variant pins_arduino.h
+       // bus:1 unspecified, emits Log_E()
+    void setClock(uint32_t); // change bus clock without initing hardware
     void beginTransmission(uint16_t);
     uint8_t endTransmission(bool);
 		uint8_t	requestFrom(uint16_t address, uint8_t size, bool sendStop);
@@ -88,7 +90,7 @@ public:
     bool getDump(){return _dump;}
     void dumpInts();
     void dumpI2C(){i2cDumpI2c(i2c);}
-    size_t getClock();
+    size_t getClock(); // current bus clock rate in hz
     void setTimeOut(uint16_t timeOutMillis);
     uint16_t getTimeOut();
 //		
@@ -140,6 +142,7 @@ extern TwoWire Wire;
 
 
 /*
+V0.2.2 13APR2018 preserve custom SCL,SDA,Frequency when no parameters passed to begin()
 V0.2.1 15MAR2018 Hardware reset, Glitch prevention, adding destructor for second i2c testing
 */
 #endif

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -30,7 +30,7 @@
 #include "freertos/queue.h"
 #include "Stream.h"
 
-#define STICKBREAKER
+#define STICKBREAKER V0.2.1
 #define I2C_BUFFER_LENGTH 128
 typedef void(*user_onRequest)(void);
 typedef void(*user_onReceive)(uint8_t*, int);
@@ -69,6 +69,7 @@ protected:
 
 public:
     TwoWire(uint8_t bus_num);
+    ~TwoWire();
     void begin(int sda=-1, int scl=-1, uint32_t frequency=100000);
     void setClock(uint32_t);
     void beginTransmission(uint16_t);
@@ -113,8 +114,6 @@ public:
     int peek(void);
     void flush(void);
 
-    void reset(void);
-
     inline size_t write(const char * s)
     {
         return write((uint8_t*) s, strlen(s));
@@ -139,4 +138,8 @@ public:
 
 extern TwoWire Wire;
 
+
+/*
+V0.2.1 15MAR2018 Hardware reset, Glitch prevention, adding destructor for second i2c testing
+*/
 #endif


### PR DESCRIPTION
This destructor allows reassigning either hardware peripheral to the default Wire() object.
sequence:
```c++
Wire.~TwoWire();
Wire = TwoWire(peripheral); // peripheral is either 0 or 1
Wire.begin(sda,scl); // sda, scl are the pins to use, when using peripheral 1,
  // YOU MUST specifiy the pins, there ARE NO DEFAULT VALUES for peripheral 1.
```